### PR TITLE
feat: Add /llms.txt endpoint for profile data

### DIFF
--- a/server/hono/src/index.ts
+++ b/server/hono/src/index.ts
@@ -2,8 +2,9 @@ import { Hono } from 'hono'
 import type { HonoConfig } from './config/hono'
 import { middleware } from './middleware'
 import v1 from './routes/v1'
+import llms from './routes/llms'
 
-const app = new Hono<HonoConfig>().route('*', middleware).route('/v1', v1)
+const app = new Hono<HonoConfig>().route('*', middleware).route('/v1', v1).route('/llms.txt', llms)
 
 export default app
 

--- a/server/hono/src/routes/llms.test.ts
+++ b/server/hono/src/routes/llms.test.ts
@@ -1,0 +1,65 @@
+import app from '../index'; // Adjusted path from ../../src/index
+
+// Mocking a simple test structure
+const describe = (description: string, fn: () => void) => {
+  console.log(description);
+  fn();
+};
+
+const it = (description: string, fn: () => Promise<void> | void) => {
+  console.log(`  ${description}`);
+  return Promise.resolve(fn()).catch(err => {
+    console.error(`    FAILED: ${err.message}`);
+    process.exitCode = 1; 
+  });
+};
+
+const expect = (actual: any) => ({
+  toBe: (expected: any) => {
+    if (actual !== expected) {
+      throw new Error(`Expected ${JSON.stringify(actual)} to be ${JSON.stringify(expected)}`);
+    }
+    console.log('    PASSED');
+  },
+  toContain: (expectedSubstring: string) => {
+    if (typeof actual !== 'string' || !actual.includes(expectedSubstring)) {
+      throw new Error(`Expected "${actual}" to contain "${expectedSubstring}"`);
+    }
+    console.log('    PASSED');
+  },
+  toBeGreaterThan: (expected: number) => {
+    if (typeof actual !== 'number' || actual <= expected) {
+      throw new Error(`Expected ${actual} to be greater than ${expected}`);
+    }
+    console.log('    PASSED');
+  }
+});
+
+describe('GET /llms.txt', () => {
+  it('should return profile information in Markdown format', async () => {
+    const res = await app.request('/llms.txt');
+    
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/markdown; charset=UTF-8');
+    
+    const text = await res.text();
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain('# oidon. - umaidashi');
+    expect(text).toContain('## About');
+    expect(text).toContain('## Skills');
+    expect(text).toContain('Go'); // Example skill
+    expect(text).toContain('### Languages');
+    expect(text).toContain('Gin'); // Example framework
+    expect(text).toContain('Prisma'); // Example library
+    expect(text).toContain('PostgreSQL'); // Example RDBMS
+    expect(text).toContain('Neovim'); // Example Other
+  });
+});
+
+// Helper to run tests if this file is executed directly (e.g., with bun run server/hono/src/routes/llms.test.ts)
+// This is a simplified runner. A proper test runner like vitest or jest would be better.
+if (import.meta.path === process.argv[1] || import.meta.path.endsWith('.ts')) {
+  console.log('Running tests...');
+  // Potentially, one would aggregate test results here.
+  // For now, errors are logged and process.exitCode is set.
+}

--- a/server/hono/src/routes/llms.ts
+++ b/server/hono/src/routes/llms.ts
@@ -1,0 +1,47 @@
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+const markdownContent = `
+# oidon. - umaidashi
+
+## About
+
+| key          | value                     |
+|--------------|---------------------------|
+| Name         | Oishi Yuma                |
+| Birth Day    | 2002.11.18                |
+| Hometown     | Fukuoka                   |
+| University   | Meiji.univ                |
+| Workplace    | BuySell Technologies      |
+| Display Name | ['umaidashi', 'oidon', 'yoishi'] |
+
+## Skills
+
+### Languages
+
+Go, TypeScript, JavaScript, C, Python, Ruby, Zsh, Dart, Swift, R, Pug, Sass, Rust, Terraform
+
+### Frameworks
+
+Gin, React, Next.js, Hono, Astro, Remix, Django, Flask, Ruby on Rails, Flutter
+
+### Libraries
+
+Prisma, Drizzle, Zod, MUI, shadcn/ui, GraphQL, styled-components
+
+### RDBMS / BaaS
+
+PostgreSQL, PlanetScale, Supabase, MySQL
+
+### Others
+
+Neovim, Vim, Vercel, Render, Sentry, Datadog, New Relic, Debian, Linux, Slack, Discord, Sketch, Figma, GitHub, GitHub Actions, Docker, Google Cloud, Google BigQuery, Google Cloud Storage, Postman, Jira, Jira Software
+`;
+
+app.get('/', (c) => {
+  c.header('Content-Type', 'text/markdown; charset=UTF-8');
+  return c.text(markdownContent);
+});
+
+export default app;


### PR DESCRIPTION
This commit introduces a new endpoint `/llms.txt` to the Hono server. This endpoint serves the content of the profile page in Markdown format.

The profile data is sourced statically, similar to the Remix profile page, and includes sections for "About" and "Skills".

A test case has been added to verify:
- The endpoint returns a 200 OK status.
- The `Content-Type` is `text/markdown; charset=UTF-8`.
- The response body contains the expected Markdown structure and content.