### PR TITLE
Fix og:title meta attribute

### DIFF
--- a/views/2024-remix/app/routes/posts.$id/index.tsx
+++ b/views/2024-remix/app/routes/posts.$id/index.tsx
@@ -20,7 +20,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
       name: 'description',
       content: `${data.data.body.slice(0, 100)}...`
     },
-    { property: 'og:title', title },
+    { property: 'og:title', content: title },
     {
       property: 'og:description',
       content: description


### PR DESCRIPTION
## Summary
- update `og:title` meta tag syntax to correctly use `content`

## Testing
- `bun x biome check --apply views/2024-remix/app/routes/posts.$id/index.tsx`

------
https://chatgpt.com/codex/tasks/task_e_683ff776ef8883328dd7219953bb9728