### PR TITLE
Fix missing Env type for Remix client

### DIFF
--- a/views/2024-remix/app/client.ts
+++ b/views/2024-remix/app/client.ts
@@ -1,6 +1,11 @@
 import type { HC } from '@server/hono'
 import { hc } from 'hono/client'
 
+type Env = {
+  API_URL: string
+  API_TOKEN: string
+}
+
 export const createClient = (env: Env) => {
   const url = env.API_URL
   const token = env.API_TOKEN


### PR DESCRIPTION
## Summary
- define the `Env` type in `views/2024-remix/app/client.ts`

## Testing
- `npx @biomejs/biome lint views/2024-remix/app/client.ts`
- `npx @biomejs/biome lint views/2024-remix/app`

------
https://chatgpt.com/codex/tasks/task_e_683fe8f5ae008332a6d349cf850d4b32