### PR TITLE
Fix alt attribute typo

### DIFF
--- a/views/2024-remix/app/routes/_index/index.tsx
+++ b/views/2024-remix/app/routes/_index/index.tsx
@@ -97,7 +97,7 @@ export default function Index() {
           <img
             className='h-full w-full object-cover rounded-[--radius]'
             src='profile.png'
-            alt='prifile'
+            alt='profile'
           />
         </Link>
         <Link


### PR DESCRIPTION
## Summary
- fix alt text typo in 2024-remix index route

## Testing
- `npm run lint` *(fails: Next.js lint in ogp-generator prompts for config)*
- `npx turbo run lint --filter=@views/2024-remix`

------
https://chatgpt.com/codex/tasks/task_e_683ff76e899483328677aa226debed18