### PR TITLE
Add Bun tests to CI

### DIFF
--- a/.github/workflows/hono_test.yaml
+++ b/.github/workflows/hono_test.yaml
@@ -1,0 +1,28 @@
+name: hono_test
+
+on:
+  push:
+    paths:
+      - 'server/hono/**'
+      - '.github/workflows/hono_test.yaml'
+  pull_request:
+    paths:
+      - 'server/hono/**'
+      - '.github/workflows/hono_test.yaml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun test
+        working-directory: server/hono

--- a/server/hono/README.md
+++ b/server/hono/README.md
@@ -1,1 +1,9 @@
 # Serve Blog Contents to View
+
+## Tests
+
+Run unit tests with:
+
+```bash
+bun test
+```

--- a/server/hono/package.json
+++ b/server/hono/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "wrangler dev src/index.ts",
     "deploy": "wrangler deploy --minify src/index.ts",
-    "lint": "biome check --write ./"
+    "lint": "biome check --write ./",
+    "test": "bun test"
   },
   "dependencies": {
     "@octokit/rest": "^21.0.0",

--- a/server/hono/src/di/container.test.ts
+++ b/server/hono/src/di/container.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { DIContainer } from "./container";
+
+class Foo {
+  constructor(public value: number) {}
+}
+
+class Bar {
+  constructor(public value: string) {}
+}
+
+describe("DIContainer", () => {
+  it("register stores an instance", () => {
+    const container = new DIContainer<{ foo: Foo }>();
+    container.register("foo", Foo, 123);
+    const instance = container.get("foo");
+    expect(instance).toBeInstanceOf(Foo);
+    expect(instance.value).toBe(123);
+    expect(container.get("foo")).toBe(instance);
+  });
+
+  it("get throws when dependency is not registered", () => {
+    const container = new DIContainer<{ bar: Bar }>();
+    expect(() => container.get("bar")).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow `hono_test` to run bun tests
- existing test verifies DIContainer registration and retrieval logic

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683ff788d9c48332949cb03cd968cb75